### PR TITLE
Fix toString on LazyArray which did not conserve escaped chars

### DIFF
--- a/src/main/java/me/doubledutch/lazyjson/LazyArray.java
+++ b/src/main/java/me/doubledutch/lazyjson/LazyArray.java
@@ -52,9 +52,13 @@ public class LazyArray extends LazyElement{
 				buf.append(new LazyObject(pointer).toString());
 			}else if(pointer.type==LazyNode.ARRAY){
 				buf.append(new LazyArray(pointer).toString());
-			}else if(pointer.type==LazyNode.VALUE_STRING || pointer.type==LazyNode.VALUE_ESTRING){
+			}else if(pointer.type==LazyNode.VALUE_STRING){
 				buf.append("\"");
 				buf.append(pointer.getStringValue());
+				buf.append("\"");
+			}else if (pointer.type==LazyNode.VALUE_ESTRING){
+				buf.append("\"");
+				buf.append(pointer.getRawStringValue());
 				buf.append("\"");
 			}else if(pointer.type==LazyNode.VALUE_TRUE){
 				buf.append("true");

--- a/src/test/java/me/doubledutch/lazyjson/LazyArrayTest.java
+++ b/src/test/java/me/doubledutch/lazyjson/LazyArrayTest.java
@@ -314,4 +314,12 @@ public class LazyArrayTest{
         assertNotNull(obj2);
         assertEquals(obj.getString("[]"),"{}");
     }
+
+    @Test
+    public void testSerializeStringWithEscapedQuotes() {
+        LazyArray lazyArray = new LazyArray();
+        lazyArray.put("\"foo\" bar");
+        lazyArray.put("baz");
+        assertEquals("[\"\\\"foo\\\" bar\",\"baz\"]", lazyArray.toString());
+    }
 }


### PR DESCRIPTION
Attempt at fixing https://github.com/doubledutch/LazyJSON/issues/17, I wrote a failing test which now passes and all the tests still pass.